### PR TITLE
tiny2

### DIFF
--- a/eembc/CIFAR10_ResNetv1/tiny2.yml
+++ b/eembc/CIFAR10_ResNetv1/tiny2.yml
@@ -1,0 +1,154 @@
+save_dir: resnet_v1_eembc_quantized_javquant2
+
+model:
+  name: resnet_v1_eembc_quantized
+  filters:
+  - 32
+  - 4
+  - 32
+  - 32
+  l1: 0
+  l2: 1e-4
+  kernels:
+  - 1
+  - 4
+  - 4
+  - 4
+  - 4
+  - 4
+  strides:
+  - '111'
+  - '414'
+  skip: 0
+  avg_pooling: 0
+  final_activation: 1
+
+pruning:
+  sparsity: 1.0
+
+fit:
+  compile:
+    initial_lr: 0.001
+    lr_decay: 0.99
+    optimizer: Adam
+    loss: categorical_crossentropy
+  epochs: 200
+  patience: 40
+  batch_size: 32
+  verbose: 1
+
+quantization:
+  logit_total_bits: 8
+  logit_int_bits: 2
+  logit_quantizer: quantized_bits
+  activation_total_bits: 8
+  activation_int_bits: 2
+  activation_quantizer: quantized_relu
+  alpha: 1
+  use_stochastic_rounding: 0
+
+convert:
+  RemoveSoftmax: 1
+  OutputDir: my-hls-test-quantized-tiny2
+  XilinxPart: xc7z020clg400-1
+  Backend: Vivado
+  IOType: io_stream
+  Interface: axi_stream
+  Driver: python
+  Board: pynq-z2
+  Precision: ap_fixed<8,6>
+  ReuseFactor: 16384
+  Trace: 0
+  Build: 1
+  ClockPeriod: 10
+  Strategy: Resource
+  Override:
+    input_1:
+      Precision: ap_ufixed<8,0>
+    q_conv2d_batchnorm:
+      accum_t: ap_fixed<14,6>
+      Precision:
+        weight: ap_fixed<8,3>
+        bias: ap_fixed<8,3>
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+      ConvImplementation: 'Encoded'
+    q_conv2d_batchnorm_linear:
+      Precision:
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+    q_activation:
+      Precision:
+        default: ap_fixed<9,6>
+        result: ap_fixed<8,3,AP_RND,AP_SAT>
+    q_conv2d_batchnorm_1:
+      accum_t: ap_fixed<14,6>
+      Precision:
+        weight: ap_fixed<8,3>
+        bias: ap_fixed<8,3>
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+      ConvImplementation: 'Encoded'
+    q_conv2d_batchnorm_1_linear:
+      Precision:
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+    q_activation_1:
+      Precision:
+        default: ap_fixed<9,6>
+        result: ap_fixed<8,3,AP_RND,AP_SAT>
+    q_conv2d_batchnorm_2:
+      accum_t: ap_fixed<14,6>
+      Precision:
+        weight: ap_fixed<8,3>
+        bias: ap_fixed<8,3>
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+      ConvImplementation: 'Encoded'
+    q_conv2d_batchnorm_2_linear:
+      Precision:
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+    q_activation_2:
+      Precision:
+        default: ap_fixed<9,6>
+        result: ap_fixed<8,3,AP_RND,AP_SAT>
+    q_conv2d_batchnorm_3:
+      accum_t: ap_fixed<14,6>
+      Precision:
+        weight: ap_fixed<8,3>
+        bias: ap_fixed<8,3>
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+      ConvImplementation: 'Encoded'
+    q_conv2d_batchnorm_3_linear:
+      Precision:
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+    q_activation_3:
+      Precision:
+        default: ap_fixed<9,6>
+        result: ap_fixed<8,3,AP_RND,AP_SAT>
+    q_conv2d_batchnorm_4:
+      accum_t: ap_fixed<14,6>
+      Precision:
+        weight: ap_fixed<8,3>
+        bias: ap_fixed<8,3>
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+      ConvImplementation: 'Encoded'
+    q_conv2d_batchnorm_4_linear:
+      Precision:
+        result: ap_fixed<9,6>
+        default: ap_fixed<9,6>
+    q_activation_4:
+      Precision:
+        default: ap_fixed<9,6>
+        result: ap_fixed<8,3,AP_RND,AP_SAT>
+    q_dense:
+      accum_t: ap_fixed<12,6>
+      Precision:
+        weight: ap_fixed<8,3>
+        bias: ap_fixed<8,3>
+        result: ap_fixed<8,6>
+        default: ap_fixed<8,6>

--- a/eembc/CIFAR10_ResNetv1/tiny2.yml
+++ b/eembc/CIFAR10_ResNetv1/tiny2.yml
@@ -1,4 +1,4 @@
-save_dir: resnet_v1_eembc_quantized_javquant2
+save_dir: resnet_v1_eembc_quantized_tiny2
 
 model:
   name: resnet_v1_eembc_quantized


### PR DESCRIPTION
- yaml for tiny2 (previously called javquant2 from: https://docs.google.com/presentation/d/1QCyRCwpDG9RCzbKFx2rMDeW5o_H0niEm_0kdErSmw74/edit#slide=id.gd721b428c5_0_9)